### PR TITLE
fix: add/updated item in cache dictionary

### DIFF
--- a/src/Spid.Cie.OIDC.AspNetCore/Services/TrustChainManager.cs
+++ b/src/Spid.Cie.OIDC.AspNetCore/Services/TrustChainManager.cs
@@ -50,10 +50,10 @@ class TrustChainManager : ITrustChainManager
     {
         if (!_rpTrustChainCache.ContainsKey(url) || _rpTrustChainCache[url].ExpiresOn < DateTimeOffset.UtcNow)
         {
-            if (!await _syncLock.WaitAsync(TimeSpan.FromSeconds(10)))
+            while (!await _syncLock.WaitAsync(TimeSpan.FromSeconds(10)))
             {
-                _logger.LogWarning("TrustChain cache Sync Lock expired.");
-                return default;
+                _logger.LogWarning("TrustChain cache Sync Lock expired. Release It!");
+                _syncLock.Release();
             }
 
             if (!_rpTrustChainCache.ContainsKey(url) || _rpTrustChainCache[url].ExpiresOn < DateTimeOffset.UtcNow)
@@ -178,10 +178,10 @@ class TrustChainManager : ITrustChainManager
     {
         if (!_idpTrustChainCache.ContainsKey(url) || _idpTrustChainCache[url].ExpiresOn < DateTimeOffset.UtcNow)
         {
-            if (!await _syncLock.WaitAsync(TimeSpan.FromSeconds(10)))
+            while (!await _syncLock.WaitAsync(TimeSpan.FromSeconds(10)))
             {
-                _logger.LogWarning("TrustChain cache Sync Lock expired.");
-                return default;
+                _logger.LogWarning("TrustChain cache Sync Lock expired. Release it!");
+                _syncLock.Release();
             }
 
             if (!_idpTrustChainCache.ContainsKey(url) || _idpTrustChainCache[url].ExpiresOn < DateTimeOffset.UtcNow)

--- a/src/Spid.Cie.OIDC.AspNetCore/Services/TrustChainManager.cs
+++ b/src/Spid.Cie.OIDC.AspNetCore/Services/TrustChainManager.cs
@@ -146,13 +146,14 @@ class TrustChainManager : ITrustChainManager
 
                     if (rpValidated && rpConf is not null && trustAnchorUsed is not null)
                     {
-                        _rpTrustChainCache.AddOrUpdate(url, new TrustChain<RPEntityConfiguration>()
+                        var updatedExpiredOn = new TrustChain<RPEntityConfiguration>()
                         {
                             ExpiresOn = expiresOn,
                             EntityConfiguration = rpConf,
                             Chain = trustChain,
                             TrustAnchorUsed = trustAnchorUsed
-                        }, (oldValue, newValue) => newValue);
+                        };
+                        _rpTrustChainCache.AddOrUpdate(url, updatedExpiredOn, (key, oldValue) => updatedExpiredOn);
                     }
                 }
                 catch (Exception ex)
@@ -271,14 +272,15 @@ class TrustChainManager : ITrustChainManager
                     }
                     if (opValidated && opConf is not null && trustAnchorUsed is not null)
                     {
-                        _idpTrustChainCache.AddOrUpdate(url, new TrustChain<OPEntityConfiguration>()
+                        var updatedExpiredOn = new TrustChain<OPEntityConfiguration>()
                         {
                             ExpiresOn = expiresOn,
                             EntityConfiguration = opConf,
                             //OpConf = opConf,
                             Chain = trustChain,
                             TrustAnchorUsed = trustAnchorUsed
-                        }, (oldValue, newValue) => newValue);
+                        };
+                        _idpTrustChainCache.AddOrUpdate(url, updatedExpiredOn, (key, oldValue) => updatedExpiredOn);
                     }
                 }
                 catch (Exception ex)


### PR DESCRIPTION
fix: changed way to call AddOrUpdate in each cache dictionary

Non so se ho compreso bene il significato del codice. 

Mi sono limitato a fare in modo che venisse effettivamente aggiunto dentro entrambi i `ConcurrentDictionary` l'elemento nuovo con la nuova scadenza verificando il funzionamento della funzione `AddOrUpdate` come documentato [qui](https://learn.microsoft.com/it-it/dotnet/api/system.collections.concurrent.concurrentdictionary-2.addorupdate?view=net-9.0#system-collections-concurrent-concurrentdictionary-2-addorupdate(-0-1-system-func((-0-1-1)))). 

Verificato il corretto funzionamento solo per la funzione `BuildTrustChain` della classe `TrustChainManager`.

fixes #38 