### PR TITLE
Feat/fetch trust mark gen

### DIFF
--- a/src/Spid.Cie.OIDC.AspNetCore/Helpers/OptionsHelpers.cs
+++ b/src/Spid.Cie.OIDC.AspNetCore/Helpers/OptionsHelpers.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Extensions.Configuration;
 using Spid.Cie.OIDC.AspNetCore.Enums;
 using Spid.Cie.OIDC.AspNetCore.Models;
+using Spid.Cie.OIDC.AspNetCore.Models.OIDCFederation.TrustMarks;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -33,6 +34,7 @@ static class OptionsHelpers
             var relyingParty = new RelyingParty
             {
                 Id = relyingPartySection.GetValue<string?>("Id") ?? string.Empty,
+                IdCode = relyingPartySection.GetSection("IdCode").Get<TrustMarkGovernmentIndex?>(),
                 Name = relyingPartySection.GetValue<string?>("Name") ?? string.Empty,
                 OrganizationName = relyingPartySection.GetValue<string?>("OrganizationName") ?? string.Empty,
                 OrganizationType = relyingPartySection.GetValue<string?>("OrganizationType") ?? string.Empty,
@@ -105,6 +107,7 @@ static class OptionsHelpers
                 var relyingParty = new RelyingParty
                 {
                     Id = relyingPartySection.GetValue<string?>("Id") ?? string.Empty,
+                    IdCode = relyingPartySection.GetSection("IdCode").Get<TrustMarkGovernmentIndex?>(),
                     SecurityLevel = securityLevel == 1 ? SecurityLevels.L1 : securityLevel == 3 ? SecurityLevels.L3 : SecurityLevels.L2,
                     Contacts = relyingPartySection.GetSection("Contacts").Get<List<string>?>() ?? new List<string>(),
                     RedirectUris = new List<string>() { $"{(relyingPartySection.GetValue<string?>("Id") ?? string.Empty).RemoveTrailingSlash()}{SpidCieConst.CallbackPath}" },

--- a/src/Spid.Cie.OIDC.AspNetCore/Helpers/StringHelpers.cs
+++ b/src/Spid.Cie.OIDC.AspNetCore/Helpers/StringHelpers.cs
@@ -25,4 +25,13 @@ static class StringHelpers
 
         return url;
     }
+
+    public static int IndexOfOccurence(this string s, string match, int occurence)
+    {
+        var idx = s.IndexOf(match, 0);
+        var nth = occurence;
+        while (idx >= 0 && --nth > 0)
+            idx = s.IndexOf(match, idx + 1);
+        return idx;
+    }
 }

--- a/src/Spid.Cie.OIDC.AspNetCore/Middlewares/FetchOpenIdFederationMiddleware.cs
+++ b/src/Spid.Cie.OIDC.AspNetCore/Middlewares/FetchOpenIdFederationMiddleware.cs
@@ -215,9 +215,9 @@ class FetchOpenIdFederationMiddleware
             return false;
         }
 
-        trustmark = rp.TrustMarks.Where(x => x.Issuer == aggregate.Id).FirstOrDefault();
+        trustmark = rp.TrustMarks.Where(x => x.Issuer == aggregate.Id).FirstOrDefault() ?? new TrustMarkDefinition();
 
-        if (trustmark == default || string.IsNullOrEmpty(trustmark.TrustMark))
+        if (string.IsNullOrEmpty(trustmark.TrustMark))
         {
             return false;
         }

--- a/src/Spid.Cie.OIDC.AspNetCore/Middlewares/FetchOpenIdFederationMiddleware.cs
+++ b/src/Spid.Cie.OIDC.AspNetCore/Middlewares/FetchOpenIdFederationMiddleware.cs
@@ -121,7 +121,7 @@ class FetchOpenIdFederationMiddleware
             {
                 Id =  id,
                 Issuer = aggregate.Id,
-                TrustMark = cryptoService.CreateJWT(certificate, JsonSerializer.Serialize<TrustMarkPayload>(trustMark))
+                TrustMark = cryptoService.CreateJWT(certificate, trustMark)
             };
             
             

--- a/src/Spid.Cie.OIDC.AspNetCore/Middlewares/FetchOpenIdFederationMiddleware.cs
+++ b/src/Spid.Cie.OIDC.AspNetCore/Middlewares/FetchOpenIdFederationMiddleware.cs
@@ -8,7 +8,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
-using System.Runtime.CompilerServices;
 using System.Security.Cryptography.X509Certificates;
 using System.Text.Json;
 using System.Threading.Tasks;

--- a/src/Spid.Cie.OIDC.AspNetCore/Middlewares/FetchOpenIdFederationMiddleware.cs
+++ b/src/Spid.Cie.OIDC.AspNetCore/Middlewares/FetchOpenIdFederationMiddleware.cs
@@ -124,12 +124,13 @@ class FetchOpenIdFederationMiddleware
             var id = $"{aggrTrustMarkId.Substring(0,aggrTrustMarkId.IndexOfOccurence("/",3))}/openid_relying_party/{relyingParty.OrganizationType?.ToLower()}";
 
             var emission = DateTimeOffset.Now;
+            var expireson = new DateTimeOffset(new DateTime(emission.Year, emission.Month, emission.Day, 0, 0, 0)).AddYears(1);
             var trustMark = new TrustMarkPayload() {
                 Subject = relyingParty.Id,
                 Issuer = aggregate.Id,
                 OrganizationType = relyingParty.OrganizationType?.ToLower(),
                 Id = id,
-                ExpiresOn = new DateTimeOffset(emission.Year, emission.Month, emission.Day, 0, 0, 0, emission.TimeOfDay).AddYears(1),
+                ExpiresOn = expireson,
                 IssuedAt = emission,
             };
 

--- a/src/Spid.Cie.OIDC.AspNetCore/Middlewares/FetchOpenIdFederationMiddleware.cs
+++ b/src/Spid.Cie.OIDC.AspNetCore/Middlewares/FetchOpenIdFederationMiddleware.cs
@@ -125,13 +125,16 @@ class FetchOpenIdFederationMiddleware
 
             var emission = DateTimeOffset.Now;
             var expireson = new DateTimeOffset(new DateTime(emission.Year, emission.Month, emission.Day, 0, 0, 0)).AddYears(1);
-            var trustMark = new TrustMarkPayload() {
+            var trustMark = new TrustMarkPayload()
+            {
                 Subject = relyingParty.Id,
                 Issuer = aggregate.Id,
                 OrganizationType = relyingParty.OrganizationType?.ToLower(),
                 Id = id,
                 ExpiresOn = expireson,
                 IssuedAt = emission,
+                IdCode = relyingParty.IdCode,
+                Email = relyingParty.Contacts.Count() == 0? null : string.Join(",", relyingParty.Contacts),
             };
 
 

--- a/src/Spid.Cie.OIDC.AspNetCore/Middlewares/FetchOpenIdFederationMiddleware.cs
+++ b/src/Spid.Cie.OIDC.AspNetCore/Middlewares/FetchOpenIdFederationMiddleware.cs
@@ -224,12 +224,12 @@ class FetchOpenIdFederationMiddleware
 
         foreach (var tm in trustmarks)
         {
-            if (string.IsNullOrEmpty(trustmark.TrustMark))
+            if (string.IsNullOrEmpty(tm.TrustMark))
             {
                 continue;
             }
 
-            var tmp = JsonSerializer.Deserialize<TrustMarkPayload>(cryptoService.DecodeJWT(trustmark.TrustMark));
+            var tmp = JsonSerializer.Deserialize<TrustMarkPayload>(cryptoService.DecodeJWT(tm.TrustMark));
 
             // return new trust mark before it expire, add 5 days to invalidate actual RP trust mark and generate new ones
             // the new trust mark and the old ones result in the fetch response 

--- a/src/Spid.Cie.OIDC.AspNetCore/Middlewares/FetchOpenIdFederationMiddleware.cs
+++ b/src/Spid.Cie.OIDC.AspNetCore/Middlewares/FetchOpenIdFederationMiddleware.cs
@@ -121,8 +121,9 @@ class FetchOpenIdFederationMiddleware
                 return;
             }
 
+            // generate a new trust mark valid
+            // ATTENTION!: expired trust mark should be manually removed from appsettings.json of SA and RP and the new trust mark should be added manually to appsettings.json of SA and RP
             var id = $"{aggrTrustMarkId.Substring(0,aggrTrustMarkId.IndexOfOccurence("/",3))}/openid_relying_party/{relyingParty.OrganizationType?.ToLower()}";
-
             var emission = DateTimeOffset.Now;
             var expireson = new DateTimeOffset(new DateTime(emission.Year, emission.Month, emission.Day, 0, 0, 0)).AddYears(1);
             var trustMark = new TrustMarkPayload()
@@ -212,26 +213,35 @@ class FetchOpenIdFederationMiddleware
     private bool RPHaveValidTrustMark(ICryptoService cryptoService, RelyingParty rp, Aggregator aggregate, out TrustMarkDefinition trustmark) 
     {
         trustmark = new TrustMarkDefinition();
+        var res = false;
 
         if (rp.TrustMarks is null || !rp.TrustMarks.Any())
         {
-            return false;
+            return res;
         }
 
-        trustmark = rp.TrustMarks.Where(x => x.Issuer == aggregate.Id).FirstOrDefault() ?? new TrustMarkDefinition();
+        var trustmarks = rp.TrustMarks.Where(x => x.Issuer == aggregate.Id);
 
-        if (string.IsNullOrEmpty(trustmark.TrustMark))
+        foreach (var tm in trustmarks)
         {
-            return false;
+            if (string.IsNullOrEmpty(trustmark.TrustMark))
+            {
+                continue;
+            }
+
+            var tmp = JsonSerializer.Deserialize<TrustMarkPayload>(cryptoService.DecodeJWT(trustmark.TrustMark));
+
+            // return new trust mark before it expire, add 5 days to invalidate actual RP trust mark and generate new ones
+            // the new trust mark and the old ones result in the fetch response 
+            if (tmp is null || tmp is not null && tmp.ExpiresOn.AddDays(5) <= DateTimeOffset.Now)
+            {
+                continue;
+            }
+
+            trustmark = tm;
+            res = true;
         }
 
-        var tmp = JsonSerializer.Deserialize<TrustMarkPayload>(cryptoService.DecodeJWT(trustmark.TrustMark));
-
-        if (tmp is null || tmp is not null && tmp.ExpiresOn <= DateTimeOffset.Now)
-        {
-            return false;
-        }
-
-        return true;
+        return res;
     }
 }

--- a/src/Spid.Cie.OIDC.AspNetCore/Middlewares/FetchOpenIdFederationMiddleware.cs
+++ b/src/Spid.Cie.OIDC.AspNetCore/Middlewares/FetchOpenIdFederationMiddleware.cs
@@ -144,7 +144,7 @@ class FetchOpenIdFederationMiddleware
                 Issuer = aggregate.Id,
                 TrustMark = cryptoService.CreateJWT(certificate, trustMark)
             };
-            
+            relyingParty.TrustMarks.Add(trustMarkDef);
             
             var resp = new EntityStatement()
             {
@@ -154,7 +154,7 @@ class FetchOpenIdFederationMiddleware
                 Subject = sub,
                 JWKS = cryptoService.GetJWKS(new List<X509Certificate2>() { certificate }),
                 MetadataPolicy = aggregate.MetadataPolicy,
-                TrustMarks = new List<TrustMarkDefinition>(){ trustMarkDef },
+                TrustMarks = relyingParty.TrustMarks,
                 AuthorityHints = relyingParty.AuthorityHints,
                 OpenIdRelyingParty = new SA_SpidCieOIDCConfiguration
                 {

--- a/src/Spid.Cie.OIDC.AspNetCore/Models/OIDCFederation/TrustMarks/TrustMarkGovernmentIndex.cs
+++ b/src/Spid.Cie.OIDC.AspNetCore/Models/OIDCFederation/TrustMarks/TrustMarkGovernmentIndex.cs
@@ -1,11 +1,11 @@
-﻿using Newtonsoft.Json;
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
 
 namespace Spid.Cie.OIDC.AspNetCore.Models.OIDCFederation.TrustMarks;
 
 [ExcludeFromCodeCoverage]
-class TrustMarkGovernmentIndex
+public class TrustMarkGovernmentIndex
 {
-    [JsonProperty("ipa_code")]
+    [JsonPropertyName("ipa_code")]
     public string? Code { get; set; }
 }

--- a/src/Spid.Cie.OIDC.AspNetCore/Models/OIDCFederation/TrustMarks/TrustMarkPayload.cs
+++ b/src/Spid.Cie.OIDC.AspNetCore/Models/OIDCFederation/TrustMarks/TrustMarkPayload.cs
@@ -11,23 +11,29 @@ class TrustMarkPayload : ConfigurationBaseInfo
     public string? Id { get; set; }
 
     [JsonPropertyName("logo_uri")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? LogoUri { get; set; }
 
     [JsonPropertyName("ref")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? Ref { get; set; }
 
     [JsonPropertyName("organization_type")]
     public string? OrganizationType { get; set; }
 
     [JsonPropertyName("organization_name")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? OrganizationName { get; set; }
 
     [JsonPropertyName("id_code")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public TrustMarkGovernmentIndex? IdCode { get; set; }
 
     [JsonPropertyName("email")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? Email { get; set; }
 
     [JsonPropertyName("sa_profile")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? SAProfile { get; set; }
 }

--- a/src/Spid.Cie.OIDC.AspNetCore/Models/RelyingParty.cs
+++ b/src/Spid.Cie.OIDC.AspNetCore/Models/RelyingParty.cs
@@ -1,4 +1,5 @@
 ﻿using Spid.Cie.OIDC.AspNetCore.Enums;
+using Spid.Cie.OIDC.AspNetCore.Models.OIDCFederation.TrustMarks;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Security.Cryptography.X509Certificates;
@@ -9,6 +10,8 @@ namespace Spid.Cie.OIDC.AspNetCore.Models;
 public sealed class RelyingParty
 {
     public string? Id { get; set; }
+    
+    public TrustMarkGovernmentIndex? IdCode { get; set; }
 
     public string? Name { get; set; }
 


### PR DESCRIPTION
feat: added trust mark gen in fetch endpoint
feat: trust mark gen if empty
feat: trust mark gen if expired
feat: added helper to get index of nth occur
feat: added code to ignore item in TrustMarkPayload

Related #40 

Aggiunge la possibilità di generare un trust mark che i soggetti aggregati nel momento in cui questi ultimi non hanno un trust mark o hanno un trust mark scaduto.